### PR TITLE
Try catch for hashlink using localhost function

### DIFF
--- a/src/bson/ObjectId.hx
+++ b/src/bson/ObjectId.hx
@@ -41,6 +41,8 @@ private class ObjectIdBase {
 	static var machine = Bytes.ofString(Md5.encode(
 		#if php
 			try sys.net.Host.localhost() catch(e:Dynamic) 'php'
+		#elseif hl
+			try sys.net.Host.localhost() catch(e:Dynamic) 'hl' 
 		#elseif sys 
 			sys.net.Host.localhost() 
 		#else 


### PR DESCRIPTION
Currently getting this error from the function:
```
Called from $String.fromUTF8(C:\Users\____\AppData\Roaming/haxe/versions/4.1.4/std/hl/_std/String.hx:240)
Called from sys.net.$Host.localhost(C:\Users\_____\AppData\Roaming/haxe/versions/4.1.4/std/hl/_std/sys/net/Host.hx:47)
Called from fun$606(bson/ObjectId.hx:45)
```